### PR TITLE
revert casperjs version to 1.1.0-beta5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Vadim Sikora <vadim.sikora@divio.com>",
   "license": "MIT",
   "dependencies": {
-    "casperjs": "1.1.1",
+    "casperjs": "1.1.0-beta5",
     "phantomjs-prebuilt": "^2.1.7",
     "bluebird": "^3.3.4",
     "lodash": "^4.8.2",


### PR DESCRIPTION
this needs further investigation, but it seems that the mouse
events are broken in latest
